### PR TITLE
Fix :: index typo

### DIFF
--- a/Sources/Webber/Tools/Webber+Index.swift
+++ b/Sources/Webber/Tools/Webber+Index.swift
@@ -37,7 +37,7 @@ extension Webber {
         .error { color: #ff2b2b!important; }
         .progress {
             position: fixed;
-            left 0px;
+            left: 0px;
             top: 0px;
             height: 3px;
             width: 100%;


### PR DESCRIPTION
Left property did not have : in code creating index html

```swift
        .progress {
             position: fixed;
             left 0px;
             left: 0px;
             top: 0px;
```
to
```swift
        .progress {
             position: fixed;
             left: 0px;
             left: 0px;
             top: 0px;
```